### PR TITLE
Erlang 17 no longer supported. Go to 21.3 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: erlang
 
 otp_release:
-    - 17.4
+    - 21.3
 
 before_install:
     - wget https://s3.amazonaws.com/rebar3/rebar3


### PR DESCRIPTION
Looks like erlang 17 is no longer supported. Upgrading to 21.3 as the base version. We'll add 22 soon to support that "last two releases"